### PR TITLE
Test tenant and middleware for integration tests

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -35,7 +35,7 @@ module ActsAsTenant
   end
 
   def self.current_tenant
-    RequestStore.store[:current_tenant] || self.default_tenant
+    RequestStore.store[:current_tenant] || test_tenant || default_tenant
   end
 
   def self.unscoped=(unscoped)
@@ -51,6 +51,8 @@ module ActsAsTenant
   end
 
   class << self
+    attr_accessor :test_tenant
+
     def default_tenant=(tenant)
       @default_tenant = tenant
     end
@@ -212,13 +214,13 @@ module ActsAsTenant
               if instance.new_record?
                 unless self.class.where(fkey.to_sym => [nil, instance[fkey]],
                                         field.to_sym => instance[field]).empty?
-                  errors.add(field, 'has already been taken') 
+                  errors.add(field, 'has already been taken')
                 end
               else
                 unless self.class.where(fkey.to_sym => [nil, instance[fkey]],
                                         field.to_sym => instance[field])
                                  .where.not(:id => instance.id).empty?
-                  errors.add(field, 'has already been taken') 
+                  errors.add(field, 'has already been taken')
                 end
 
               end

--- a/lib/acts_as_tenant/test_tenant_middleware.rb
+++ b/lib/acts_as_tenant/test_tenant_middleware.rb
@@ -1,0 +1,15 @@
+module ActsAsTenant
+  class TestTenantMiddleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      previously_set_test_tenant = ActsAsTenant.test_tenant
+      ActsAsTenant.test_tenant = nil
+      @app.call(env)
+    ensure
+      ActsAsTenant.test_tenant = previously_set_test_tenant
+    end
+  end
+end

--- a/spec/acts_as_tenant/test_tenant_middleware_spec.rb
+++ b/spec/acts_as_tenant/test_tenant_middleware_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+require 'acts_as_tenant/test_tenant_middleware'
+require 'active_record_models'
+
+describe ActsAsTenant::TestTenantMiddleware do
+  after { ActsAsTenant.current_tenant = nil }
+  subject { request.get('/some/path') }
+
+  let(:middleware) { described_class.new(app) }
+  let(:request) { Rack::MockRequest.new(middleware) }
+
+  let!(:account1) { Account.create }
+  let!(:account2) { Account.create }
+
+  class TestRackApp1
+    def call(_env)
+      ActsAsTenant.current_tenant = Account.first
+      TestReceiver.assert_current_id(ActsAsTenant.current_tenant.id)
+      ActsAsTenant.current_tenant = nil
+      [200, {}, ['OK']]
+    end
+  end
+
+  class TestRackApp2
+    def call(_env)
+      TestReceiver.assert_current_id(ActsAsTenant.current_tenant.try(:id))
+      [200, {}, ['OK']]
+    end
+  end
+
+  class TestReceiver
+    def self.assert_current_id(id); end
+  end
+
+  context 'when test_tenant is nil before processing' do
+    before { ActsAsTenant.test_tenant = nil }
+
+    context 'that switches tenancies' do
+      let(:app) { TestRackApp1.new }
+
+      it 'should remain nil after processing' do
+        expect(ActsAsTenant.current_tenant).to be_nil
+        expect(TestReceiver).to receive(:assert_current_id).with(account1.id)
+        expect(subject.status).to eq 200
+        expect(ActsAsTenant.current_tenant).to be_nil
+      end
+    end
+
+    context 'that does not switch tenancies' do
+      let(:app) { TestRackApp2.new }
+
+      it 'should remain nil after processing' do
+        expect(ActsAsTenant.current_tenant).to be_nil
+        expect(TestReceiver).to receive(:assert_current_id).with(nil)
+        expect(subject.status).to eq 200
+        expect(ActsAsTenant.current_tenant).to be_nil
+      end
+    end
+  end
+
+  context 'when test_tenant is assigned before processing' do
+    before { ActsAsTenant.test_tenant = account2 }
+
+    context 'that switches tenancies' do
+      let(:app) { TestRackApp1.new }
+
+      it 'should remain assigned after processing' do
+        expect(ActsAsTenant.current_tenant).to eq account2
+        expect(TestReceiver).to receive(:assert_current_id).with(account1.id)
+        expect(subject.status).to eq 200
+        expect(ActsAsTenant.current_tenant).to eq account2
+      end
+    end
+
+    context 'that does not switch tenancies' do
+      let(:app) { TestRackApp2.new }
+
+      it 'should remain assigned after processing' do
+        expect(ActsAsTenant.current_tenant).to eq account2
+        expect(TestReceiver).to receive(:assert_current_id).with(nil)
+        expect(subject.status).to eq 200
+        expect(ActsAsTenant.current_tenant).to eq account2
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds optional test_tenant and rack middleware to facilitate setup
for integration tests. This addition seeks to solve a problem
during integration testing whereby data setup is done in a tenancy,
but the tenancy is not cleared prior to initiating a request due to
a lack of tolerance for the repetitive boilerplate that would be
required. The result is that integration testing is initiated with
a tenancy already set. Moreover, this approach avoids using the
default_tenant functionality that is currently suggested during
integration testing, since doing so may conflict with an app's
use of the default_tenant.